### PR TITLE
chore: 🤖 develop watcher

### DIFF
--- a/docs/nft-example.md
+++ b/docs/nft-example.md
@@ -53,3 +53,15 @@ yarn cap:start
 ```
 
 ✨ If everything goes well, you should see the output for a generalist flow, where a user mints a DIP-721 token, gets metadata, get balance, transfers, etc.
+
+### 👨🏾‍💻 Development
+
+A develop watcher is available, that builds and runs the healthcheck for any NFT source file changes.
+
+```sh
+yarn dev:watch
+```
+
+This is useful if you are interested in providing features or changes to the code base.
+
+Also, check our [contributing guidelines](/docs/contributing.md).

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "cap:init": "git submodule update --init --recursive",
     "cap:start": "cd ./cap && dfx deploy ic-history-router && mkdir -p ../.temp && dfx canister id ic-history-router > ../.temp/ic-history-router-id",
     "dip721:healthcheck": "./healthcheck.sh",
-    "reset": "dfx stop && rm -rf .dfx && rm -rf ./target && rm -rf ./cap/.dfx && rm -rf ./cap/target && rm -rf ./.temp"
+    "reset": "dfx stop && rm -rf .dfx && rm -rf ./cap/.dfx && rm -rf ./.temp",
+    "dev:watch": "cargo watch -w ./nft/src -s 'yarn reset && dfx start --background && yes Y | SKIP_PROMPTS=1 yarn dip721:healthcheck'"
   }
 }


### PR DESCRIPTION
## Why?

A dev watcher should be available, to compile and run the healthcheck while dev

