### PR TITLE
chore: 🤖 ci should run on develop and main

### DIFF
--- a/.github/workflows/pr-healthcheck-runner.yml
+++ b/.github/workflows/pr-healthcheck-runner.yml
@@ -3,6 +3,10 @@ name: Healthcheck
 on:
   pull_request:
     branches: [ develop, main ]
+  push:
+    branches:
+      - main
+      - developer
 
   workflow_dispatch:
 


### PR DESCRIPTION
## Why?

The Develop and Main branches should run the CI Healthcheck

## How?

- Update the gh workflow

