### PR TITLE
chore: 🤖 approve dip721

### DIFF
--- a/nft/candid/nft.did
+++ b/nft/candid/nft.did
@@ -276,6 +276,7 @@ type AccountIdentifier = text;
    name: () -> (text) query;
    
    // BEGIN DIP-721 //
+   approveDip721: (user: principal, nat64: token_id) -> ();
    balanceOfDip721: (user: principal) -> (nat64) query;
    ownerOfDip721: (token_id: nat64) -> (OwnerResult) query;
    safeTransferFromDip721: (from: principal, to: principal, token_id: nat64) -> (TxReceipt);

--- a/nft/candid/nft.did
+++ b/nft/candid/nft.did
@@ -281,7 +281,7 @@ type AccountIdentifier = text;
    name: () -> (text) query;
    
    // BEGIN DIP-721 //
-   approveDip721: (user: principal, nat64: token_id) -> (ApproveResult);
+   approveDip721: (spender: principal, token_id: nat64) -> ();
    balanceOfDip721: (user: principal) -> (nat64) query;
    ownerOfDip721: (token_id: nat64) -> (OwnerResult) query;
    safeTransferFromDip721: (from: principal, to: principal, token_id: nat64) -> (TxReceipt);

--- a/nft/candid/nft.did
+++ b/nft/candid/nft.did
@@ -1,4 +1,9 @@
 // BEGIN DIP-721 //
+ type ApproveResult =
+ variant {
+   Err: ApiError;
+   Ok: Principal;
+ };
 
  type ApiError =
  variant {
@@ -276,7 +281,7 @@ type AccountIdentifier = text;
    name: () -> (text) query;
    
    // BEGIN DIP-721 //
-   approveDip721: (user: principal, nat64: token_id) -> ();
+   approveDip721: (user: principal, nat64: token_id) -> (ApproveResult);
    balanceOfDip721: (user: principal) -> (nat64) query;
    ownerOfDip721: (token_id: nat64) -> (OwnerResult) query;
    safeTransferFromDip721: (from: principal, to: principal, token_id: nat64) -> (TxReceipt);

--- a/nft/candid/nft.did
+++ b/nft/candid/nft.did
@@ -281,7 +281,7 @@ type AccountIdentifier = text;
    name: () -> (text) query;
    
    // BEGIN DIP-721 //
-   approveDip721: (spender: principal, token_id: nat64) -> ();
+   approveDip721: (spender: principal, token_id: nat64) -> (ApproveResult);
    balanceOfDip721: (user: principal) -> (nat64) query;
    ownerOfDip721: (token_id: nat64) -> (OwnerResult) query;
    safeTransferFromDip721: (from: principal, to: principal, token_id: nat64) -> (TxReceipt);

--- a/nft/candid/nft.did
+++ b/nft/candid/nft.did
@@ -2,7 +2,7 @@
  type ApproveResult =
  variant {
    Err: ApiError;
-   Ok: Principal;
+   Ok: principal;
  };
 
  type ApiError =

--- a/nft/src/ledger.rs
+++ b/nft/src/ledger.rs
@@ -88,11 +88,10 @@ impl Ledger {
     }
 
     pub async fn approve(&self, enquire_principal: &Principal, approves_principal: &Principal, token_id: u64) {
-        let ledger_instance = ledger();
-
-        if ! has_ownership_or_approval(ledger_instance, enquire_principal, approves_principal, token_id).await {
-            return;
-        }
+        // TODO: moved to the service side
+        // if ! has_ownership_or_approval(ledger_instance, enquire_principal, approves_principal, token_id).await {
+        //     return;
+        // }
 
         ledger()
             .token_approvals

--- a/nft/src/ledger.rs
+++ b/nft/src/ledger.rs
@@ -14,7 +14,7 @@ type Approvals = Vec<User>;
 pub struct Ledger {
     tokens: HashMap<TokenIndex, TokenMetadata>,
     user_tokens: HashMap<User, Vec<TokenIndex>>,
-    pub token_approvals: HashMap<TokenIndex, User>,
+    token_approvals: HashMap<TokenIndex, User>,
     operator_approvals: HashMap<User, Approvals>,
 }
 

--- a/nft/src/ledger.rs
+++ b/nft/src/ledger.rs
@@ -87,18 +87,13 @@ impl Ledger {
             .collect()
     }
 
-    pub async fn approve(&self, enquire_principal: &Principal, approves_principal: &Principal, token_id: u64) {
-        // TODO: moved to the service side
-        // if ! has_ownership_or_approval(ledger_instance, enquire_principal, approves_principal, token_id).await {
-        //     return;
-        // }
-
+    pub async fn approve(&self, approves_principal: &Principal, token_id: u64) -> Option<User> {
         ledger()
             .token_approvals
             .insert(
                 token_id,
                 User::from(approves_principal.clone()),
-            );
+            )
     }
 
     pub fn set_approval_for_all(&self, approves_principal: &Principal, approved: bool) {

--- a/nft/src/ledger.rs
+++ b/nft/src/ledger.rs
@@ -14,7 +14,7 @@ type Approvals = Vec<User>;
 pub struct Ledger {
     tokens: HashMap<TokenIndex, TokenMetadata>,
     user_tokens: HashMap<User, Vec<TokenIndex>>,
-    token_approvals: HashMap<TokenIndex, User>,
+    pub token_approvals: HashMap<TokenIndex, User>,
     operator_approvals: HashMap<User, Approvals>,
 }
 
@@ -87,13 +87,14 @@ impl Ledger {
             .collect()
     }
 
-    pub async fn approve(&self, approves_principal: &Principal, token_id: u64) -> Option<User> {
+    pub async fn approve(&self, approves_principal: &Principal, token_id: u64) -> Result<User, ApiError> {
         ledger()
             .token_approvals
             .insert(
                 token_id,
                 User::from(approves_principal.clone()),
             )
+            .ok_or(ApiError::Other)
     }
 
     pub fn set_approval_for_all(&self, approves_principal: &Principal, approved: bool) {

--- a/nft/src/service.rs
+++ b/nft/src/service.rs
@@ -219,15 +219,15 @@ async fn transfer(transfer_request: TransferRequest) -> TransferResponse {
 
 
 #[update(name = "approveDip721")]
-async fn approve_dip721(spender: Principal, token_id: u64) {
+async fn approve_dip721(spender: Principal, token_id: u64) -> Result<User, ApiError> {
     let enquire_principal = &ic::caller();
     let ledger_instance = ledger();
 
     if ! has_ownership_or_approval(&ledger_instance, &enquire_principal, &spender, token_id).await {
-        return;
+        return Err(ApiError::Unauthorized);
     }
 
-    ledger_instance.approve(&spender, token_id).await;
+    ledger_instance.approve(&spender, token_id).await
 }
 
 #[query]

--- a/nft/src/service.rs
+++ b/nft/src/service.rs
@@ -217,6 +217,19 @@ async fn transfer(transfer_request: TransferRequest) -> TransferResponse {
     Ok(Nat::from(tx_id))
 }
 
+
+#[update(name = "approveDip721")]
+async fn approveDip721(spender: Principal, token_id: u64) {
+    let enquire_principal = &ic::caller();
+    let ledger_instance = ledger();
+
+    if ! has_ownership_or_approval(&ledger_instance, &enquire_principal, &spender, token_id).await {
+        return;
+    }
+
+    ledger_instance.approve(&enquire_principal, &spender, token_id).await;
+}
+
 #[query]
 fn bearer(token_identifier: TokenIdentifier) -> AccountIdentifierReturn {
     ledger().bearer(&token_identifier)

--- a/nft/src/service.rs
+++ b/nft/src/service.rs
@@ -219,7 +219,7 @@ async fn transfer(transfer_request: TransferRequest) -> TransferResponse {
 
 
 #[update(name = "approveDip721")]
-async fn approveDip721(spender: Principal, token_id: u64) {
+async fn approve_dip721(spender: Principal, token_id: u64) {
     let enquire_principal = &ic::caller();
     let ledger_instance = ledger();
 
@@ -227,7 +227,7 @@ async fn approveDip721(spender: Principal, token_id: u64) {
         return;
     }
 
-    ledger_instance.approve(&enquire_principal, &spender, token_id).await;
+    ledger_instance.approve(&spender, token_id).await;
 }
 
 #[query]

--- a/nft/src/utils.rs
+++ b/nft/src/utils.rs
@@ -226,9 +226,9 @@ mod tests {
 
         // Business logic
         let ledger = setup_ledger(alice);
-
+    
         // Before each, Alice approves Bob
-        ledger.approve(bob, 0).await;
+        let _user = ledger.approve(bob, 0).await;
 
         // Should Bob be approved
         assert_eq!(has_approval(&ledger, bob, 0), true);

--- a/nft/src/utils.rs
+++ b/nft/src/utils.rs
@@ -228,7 +228,7 @@ mod tests {
         let ledger = setup_ledger(alice);
 
         // Before each, Alice approves Bob
-        ledger.approve(alice, bob, 0).await;
+        ledger.approve(bob, 0).await;
 
         // Should Bob be approved
         assert_eq!(has_approval(&ledger, bob, 0), true);


### PR DESCRIPTION
## Why?

An authorised "caller" should be able to "approve" or "update" the approved address for an NFT token id. As such, the approveDip721 should be implemented, as in the specification.

## How?

- Updates ledger approve
- Adds to the service
- Updates candid
