### PR TITLE
fix: 🐛 ease deserialisation of user

### DIFF
--- a/nft/candid/nft.did
+++ b/nft/candid/nft.did
@@ -2,7 +2,7 @@
  type ApproveResult =
  variant {
    Err: ApiError;
-   Ok: principal;
+   Ok: User;
  };
 
  type ApiError =

--- a/nft/src/service.rs
+++ b/nft/src/service.rs
@@ -227,7 +227,7 @@ async fn transfer(transfer_request: TransferRequest) -> TransferResponse {
 
 
 #[update(name = "approveDip721")]
-async fn approve_dip721(spender: Principal, token_id: u64) -> Result<User, ApiError> {
+async fn approve_dip721(spender: Principal, token_id: u64) -> Result<Principal, ApiError> {
     let enquire_principal = &ic::caller();
     let ledger_instance = ledger();
 
@@ -235,7 +235,15 @@ async fn approve_dip721(spender: Principal, token_id: u64) -> Result<User, ApiEr
         return Err(ApiError::Unauthorized);
     }
 
-    ledger_instance.approve(&spender, token_id).await
+    match ledger_instance.approve(&spender, token_id).await {
+        Ok(user) => {
+            match user {
+                User::principal(principal) => Ok(principal),
+                _ => Err(ApiError::Other),
+            }
+        },
+        _ => Err(ApiError::Other),
+    }
 }
 
 #[query]

--- a/nft/src/service.rs
+++ b/nft/src/service.rs
@@ -227,7 +227,7 @@ async fn transfer(transfer_request: TransferRequest) -> TransferResponse {
 
 
 #[update(name = "approveDip721")]
-async fn approve_dip721(spender: Principal, token_id: u64) -> Result<Principal, ApiError> {
+async fn approve_dip721(spender: Principal, token_id: u64) -> Result<User, ApiError> {
     let enquire_principal = &ic::caller();
     let ledger_instance = ledger();
 
@@ -235,15 +235,7 @@ async fn approve_dip721(spender: Principal, token_id: u64) -> Result<Principal, 
         return Err(ApiError::Unauthorized);
     }
 
-    match ledger_instance.approve(&spender, token_id).await {
-        Ok(user) => {
-            match user {
-                User::principal(principal) => Ok(principal),
-                _ => Err(ApiError::Other),
-            }
-        },
-        _ => Err(ApiError::Other),
-    }
+    ledger_instance.approve(&spender, token_id).await
 }
 
 #[query]


### PR DESCRIPTION
## Why?

The User causes deserialization error, use a simple type instead such as principal instead
