### PR TITLE
refactor: 💡 home prefix, split deploy nft and controllers

### DIFF
--- a/.scripts/dfx-identity.sh
+++ b/.scripts/dfx-identity.sh
@@ -2,6 +2,7 @@
 
 ALICE_HOME=$(mktemp -d 2>/dev/null || mktemp -d -t alice-temp)
 BOB_HOME=$(mktemp -d 2>/dev/null || mktemp -d -t bob-temp)
+DEFAULT_HOME="$HOME"
 
 ALICE_PRINCIPAL_ID=$(HOME=$ALICE_HOME dfx identity get-principal)
 BOB_PRINCIPAL_ID=$(HOME=$BOB_HOME dfx identity get-principal)
@@ -11,7 +12,15 @@ ALICE_PEM="$ALICE_HOME/.config/dfx/identity/default/identity.pem"
 BOB_PEM="$BOB_HOME/.config/dfx/identity/default/identity.pem"
 DEFAULT_PEM="$HOME/.config/dfx/identity/default/identity.pem"
 
-echo "🙋‍♀️ Identities"
-echo "ALICE_PRINCIPAL_ID $ALICE_PRINCIPAL_ID"
-echo "BOB_PRINCIPAL_ID $BOB_PRINCIPAL_ID"
-echo "DEFAULT_PRINCIPAL_ID $DEFAULT_PRINCIPAL_ID"
+printf "🙋‍♀️ Identities\n\n"
+
+printf "👩🏽‍🦰 ALICE_PRINCIPAL_ID (%s)\n" "$ALICE_PRINCIPAL_ID"
+printf "👩🏽‍🦰 ALICE_HOME (%s)\n" "$ALICE_HOME"
+
+printf "👨🏽‍🦰 BOB_PRINCIPAL_ID (%s)\n" "$BOB_PRINCIPAL_ID"
+printf "👨🏽‍🦰 BOB_HOME (%s)\n" "$BOB_HOME"
+
+printf "👨🏾‍💻 DEFAULT_PRINCIPAL_ID (%s)\n" "$DEFAULT_PRINCIPAL_ID"
+printf "👨🏾‍💻 DEFAULT_HOME (%s)\n" "$DEFAULT_HOME"
+
+printf "\n\n"

--- a/.scripts/dip721/deploy-nft.sh
+++ b/.scripts/dip721/deploy-nft.sh
@@ -17,9 +17,11 @@ if [[ "$MODE" == "reinstall" ]]; then
   OPTIONAL+=(--mode reinstall)
 fi
 
-dfx canister create nft --controller "$OWNER_PRINCIPAL_ID" 
+dfx canister --no-wallet \
+  create nft --controller "$OWNER_PRINCIPAL_ID" 
 
-dfx canister --network "$NETWORK" \
+dfx canister --no-wallet \
+  --network "$NETWORK" \
   install nft --argument "(
   principal \"$OWNER_PRINCIPAL_ID\",
   \"$DIP721_TOKEN_SHORT\",

--- a/.scripts/dip721/deploy-nft.sh
+++ b/.scripts/dip721/deploy-nft.sh
@@ -17,9 +17,10 @@ if [[ "$MODE" == "reinstall" ]]; then
   OPTIONAL+=(--mode reinstall)
 fi
 
-dfx deploy --no-wallet \
-  --network "$NETWORK" \
-  nft --argument "(
+dfx canister create nft --controller "$OWNER_PRINCIPAL_ID" 
+
+dfx canister --network "$NETWORK" \
+  install nft --argument "(
   principal \"$OWNER_PRINCIPAL_ID\",
   \"$DIP721_TOKEN_SHORT\",
   \"$DIP721_TOKEN_NAME\",

--- a/.scripts/dip721/set-controllers.sh
+++ b/.scripts/dip721/set-controllers.sh
@@ -9,6 +9,9 @@ NETWORK=$1
 CONTROLLER_MAIN=$2
 DIP721_TOKEN_CONTRACT_ID=$3
 
+printf "🤖 Set controllers of main (%s) and 
+DIP-721 Contract id (%s)" "$CONTROLLER_MAIN" "$DIP721_TOKEN_CONTRACT_ID"
+
 dfx canister --no-wallet \
 --network "$NETWORK" \
 call aaaaa-aa \

--- a/.scripts/healthcheck.sh
+++ b/.scripts/healthcheck.sh
@@ -26,7 +26,7 @@ deployDip721() {
 
   printf "🤖 Deploying DIP721 NFT with %s %s %s\n" "$ownerPrincipalId" "$tokenSymbol" "$tokenName"
 
-  HOME=$callerHome &&
+  HOME=$callerHome \
   npm run dip721:deploy-nft "local" "$ownerPrincipalId" "$tokenSymbol" "$tokenName" "$CAP_HISTORY_ROUTER_ID"
 
   nonFungibleContractAddress=$(dfx canister id nft)
@@ -43,7 +43,7 @@ updateControllers() {
 
   printf "🤖 Set contract (%s) controller as (%s)\n" "$nonFungibleContractAddress" "$ownerPrincipalId"
 
-  HOME=$callerHome &&
+  HOME=$callerHome \
   npm run dip721:set-controllers "local" "$ownerPrincipalId" "$nonFungibleContractAddress"
 }
 
@@ -57,7 +57,7 @@ mintDip721() {
   printf "🤖 The mintDip721 has nonFungibleContractAddress (%s), mint_for user (%s) (%s)\n" "$nonFungibleContractAddress" "$name" "$mint_for"
 
   result=$(
-    HOME=$callerHome &&
+    HOME=$callerHome \
     dfx canister --no-wallet \
       call "$nonFungibleContractAddress" \
       mintDip721 "(
@@ -72,7 +72,7 @@ mintDip721() {
 
   printf "🤖 The Balance for user %s of id (%s)\n" "$name" "$mint_for"
 
-  HOME=$callerHome &&
+  HOME=$callerHome \
   dfx canister --no-wallet \
     call "$nonFungibleContractAddress" \
     balanceOfDip721 "(
@@ -81,7 +81,7 @@ mintDip721() {
 
   printf "🤖 User %s getMetadataForUserDip721 is\n" "$name"
 
-  HOME=$callerHome &&
+  HOME=$callerHome \
   dfx canister --no-wallet \
     call "$nonFungibleContractAddress" \
     getMetadataForUserDip721 "(
@@ -97,7 +97,7 @@ supportedInterfacesDip721() {
   callerHome=$1
   nonFungibleContractAddress=$2
 
-  HOME=$callerHome &&
+  HOME=$callerHome \
   dfx canister --no-wallet \
     call "$nonFungibleContractAddress" \
     supportedInterfacesDip721 "()"
@@ -109,7 +109,7 @@ nameDip721() {
   callerHome=$1
   nonFungibleContractAddress=$2
 
-  HOME=$callerHome &&
+  HOME=$callerHome \
   dfx canister --no-wallet \
     call "$nonFungibleContractAddress" \
     nameDip721 "()"
@@ -120,7 +120,7 @@ symbolDip721() {
   
   callerHome=$1
 
-  HOME=$callerHome &&
+  HOME=$callerHome \
   dfx canister --no-wallet \
     call "$nonFungibleContractAddress" \
     symbolDip721 "()"
@@ -132,7 +132,7 @@ balanceOfDip721() {
   callerHome=$1
   user=$2
 
-  HOME=$callerHome &&
+  HOME=$callerHome \
   dfx canister --no-wallet \
     call "$nonFungibleContractAddress" \
     balanceOfDip721 "(
@@ -147,7 +147,7 @@ ownerOfDip721() {
   nonFungibleContractAddress=$2
   token_id=$3
 
-  HOME=$callerHome &&
+  HOME=$callerHome \
   dfx canister --no-wallet \
     call "$nonFungibleContractAddress" \
     ownerOfDip721 "($token_id)" 
@@ -161,7 +161,7 @@ safeTransferFromDip721() {
   to_principal=$3
   token_id=$4
 
-  HOME=$callerHome &&
+  HOME=$callerHome \
   dfx canister --no-wallet \
     call "$nonFungibleContractAddress" \
     safeTransferFromDip721 "(
@@ -179,7 +179,7 @@ transferFromDip721() {
   to_principal=$3
   token_id=$4
 
-  HOME=$callerHome &&
+  HOME=$callerHome \
   dfx canister --no-wallet \
     call "$nonFungibleContractAddress" \
     transferFromDip721 "(
@@ -208,7 +208,7 @@ getMetadataDip721() {
   nonFungibleContractAddress=$2
   token_id=$3
   
-  HOME=$callerHome &&
+  HOME=$callerHome \
   dfx canister --no-wallet \
     call "$nonFungibleContractAddress" \
     getMetadataDip721 "($token_id)"
@@ -221,7 +221,7 @@ getMetadataForUserDip721() {
   nonFungibleContractAddress=$2
   user=$3
 
-  HOME=$callerHome &&
+  HOME=$callerHome \
   dfx canister --no-wallet \
     call "$nonFungibleContractAddress" \
     getMetadataForUserDip721 "(
@@ -249,7 +249,7 @@ bearer() {
   nonFungibleContractAddress=$2
   token_id=$3
 
-  HOME=$callerHome &&
+  HOME=$callerHome \
   dfx canister --no-wallet \
     call "$nonFungibleContractAddress" \
     bearer "(\"$token_id\")"
@@ -262,7 +262,7 @@ supply() {
   nonFungibleContractAddress=$2
   token_id=$3
 
-  HOME=$callerHome &&
+  HOME=$callerHome \
   dfx canister --no-wallet \
     call "$nonFungibleContractAddress" \
     supply "(\"$token_id\")"
@@ -274,7 +274,7 @@ totalSupplyDip721() {
   callerHome=$1
   nonFungibleContractAddress=$2
 
-  HOME=$callerHome &&
+  HOME=$callerHome \
   dfx canister --no-wallet \
     call "$nonFungibleContractAddress" \
     totalSupplyDip721 "()" 
@@ -289,7 +289,7 @@ transfer() {
   token_id=$4
   amount=$5
 
-  HOME=$callerHome &&
+  HOME=$callerHome \
   dfx canister --no-wallet \
     call "$nonFungibleContractAddress" \
     transfer "(
@@ -310,37 +310,37 @@ transfer() {
 }
 
 tests() {
-  deployDip721 "$HOME" "$DEFAULT_PRINCIPAL_ID" "$DEFAULT_TOKEN_SYMBOL" "$DEFAULT_TOKEN_NAME"
+  deployDip721 "$DEFAULT_HOME" "$DEFAULT_PRINCIPAL_ID" "$DEFAULT_TOKEN_SYMBOL" "$DEFAULT_TOKEN_NAME"
 
-  updateControllers "$HOME" "$DEFAULT_PRINCIPAL_ID" "$nonFungibleContractAddress"
+  updateControllers "$DEFAULT_HOME" "$DEFAULT_PRINCIPAL_ID" "$nonFungibleContractAddress"
 
-  mintDip721 "$HOME" "Alice" "$ALICE_PRINCIPAL_ID"
+  mintDip721 "$DEFAULT_HOME" "Alice" "$ALICE_PRINCIPAL_ID"
 
-  supportedInterfacesDip721 "$HOME" "$nonFungibleContractAddress"
+  # supportedInterfacesDip721 "$DEFAULT_HOME" "$nonFungibleContractAddress"
 
-  nameDip721 "$HOME" "$nonFungibleContractAddress"
+  # nameDip721 "$DEFAULT_HOME" "$nonFungibleContractAddress"
 
-  symbolDip721 "$HOME"
+  # symbolDip721 "$DEFAULT_HOME"
 
-  getMetadataDip721 "$HOME" "$nonFungibleContractAddress" "$nft_token_id_for_alice"
+  # getMetadataDip721 "$DEFAULT_HOME" "$nonFungibleContractAddress" "$nft_token_id_for_alice"
 
-  getMetadataForUserDip721 "$HOME" "$nonFungibleContractAddress" "$ALICE_PRINCIPAL_ID" 
+  # getMetadataForUserDip721 "$DEFAULT_HOME" "$nonFungibleContractAddress" "$ALICE_PRINCIPAL_ID" 
 
-  bearer "$HOME" "$nonFungibleContractAddress" "$nft_token_id_for_alice"
+  # bearer "$DEFAULT_HOME" "$nonFungibleContractAddress" "$nft_token_id_for_alice"
 
-  supply "$HOME" "$nonFungibleContractAddress" "$ALICE_PRINCIPAL_ID"
+  # supply "$DEFAULT_HOME" "$nonFungibleContractAddress" "$ALICE_PRINCIPAL_ID"
 
-  totalSupplyDip721 "$HOME" "$nonFungibleContractAddress"
+  # totalSupplyDip721 "$DEFAULT_HOME" "$nonFungibleContractAddress"
 
-  balanceOfDip721 "$HOME" "$nonFungibleContractAddress"
+  # balanceOfDip721 "$DEFAULT_HOME" "$nonFungibleContractAddress"
   
-  ownerOfDip721 "$HOME" "$nonFungibleContractAddress" "$nft_token_id_for_alice"
+  # ownerOfDip721 "$DEFAULT_HOME" "$nonFungibleContractAddress" "$nft_token_id_for_alice"
 
-  safeTransferFromDip721 "$ALICE_HOME" "$ALICE_PRINCIPAL_ID" "$BOB_PRINCIPAL_ID" "$nft_token_id_for_alice"
+  # safeTransferFromDip721 "$ALICE_HOME" "$ALICE_PRINCIPAL_ID" "$BOB_PRINCIPAL_ID" "$nft_token_id_for_alice"
 
-  transferFromDip721 "$BOB_HOME" "$BOB_PRINCIPAL_ID" "$ALICE_PRINCIPAL_ID" "$nft_token_id_for_alice"
+  # transferFromDip721 "$BOB_HOME" "$BOB_PRINCIPAL_ID" "$ALICE_PRINCIPAL_ID" "$nft_token_id_for_alice"
 
-  transfer "$ALICE_HOME" "$ALICE_PRINCIPAL_ID" "$BOB_PRINCIPAL_ID" "$nft_token_id_for_alice" 1
+  # transfer "$ALICE_HOME" "$ALICE_PRINCIPAL_ID" "$BOB_PRINCIPAL_ID" "$nft_token_id_for_alice" 1
 
   ### not testable
   # printf "Running mintNFT"

--- a/.scripts/healthcheck.sh
+++ b/.scripts/healthcheck.sh
@@ -26,7 +26,6 @@ deployDip721() {
 
   printf "🤖 Deploying DIP721 NFT with %s %s %s\n" "$ownerPrincipalId" "$tokenSymbol" "$tokenName"
 
-  HOME=$callerHome \
   npm run dip721:deploy-nft "local" "$ownerPrincipalId" "$tokenSymbol" "$tokenName" "$CAP_HISTORY_ROUTER_ID"
 
   nonFungibleContractAddress=$(dfx canister id nft)
@@ -43,7 +42,6 @@ updateControllers() {
 
   printf "🤖 Set contract (%s) controller as (%s)\n" "$nonFungibleContractAddress" "$ownerPrincipalId"
 
-  HOME=$callerHome \
   npm run dip721:set-controllers "local" "$ownerPrincipalId" "$nonFungibleContractAddress"
 }
 
@@ -316,31 +314,31 @@ tests() {
 
   mintDip721 "$DEFAULT_HOME" "Alice" "$ALICE_PRINCIPAL_ID"
 
-  # supportedInterfacesDip721 "$DEFAULT_HOME" "$nonFungibleContractAddress"
+  supportedInterfacesDip721 "$DEFAULT_HOME" "$nonFungibleContractAddress"
 
-  # nameDip721 "$DEFAULT_HOME" "$nonFungibleContractAddress"
+  nameDip721 "$DEFAULT_HOME" "$nonFungibleContractAddress"
 
-  # symbolDip721 "$DEFAULT_HOME"
+  symbolDip721 "$DEFAULT_HOME"
 
-  # getMetadataDip721 "$DEFAULT_HOME" "$nonFungibleContractAddress" "$nft_token_id_for_alice"
+  getMetadataDip721 "$DEFAULT_HOME" "$nonFungibleContractAddress" "$nft_token_id_for_alice"
 
-  # getMetadataForUserDip721 "$DEFAULT_HOME" "$nonFungibleContractAddress" "$ALICE_PRINCIPAL_ID" 
+  getMetadataForUserDip721 "$DEFAULT_HOME" "$nonFungibleContractAddress" "$ALICE_PRINCIPAL_ID" 
 
-  # bearer "$DEFAULT_HOME" "$nonFungibleContractAddress" "$nft_token_id_for_alice"
+  bearer "$DEFAULT_HOME" "$nonFungibleContractAddress" "$nft_token_id_for_alice"
 
-  # supply "$DEFAULT_HOME" "$nonFungibleContractAddress" "$ALICE_PRINCIPAL_ID"
+  supply "$DEFAULT_HOME" "$nonFungibleContractAddress" "$ALICE_PRINCIPAL_ID"
 
-  # totalSupplyDip721 "$DEFAULT_HOME" "$nonFungibleContractAddress"
+  totalSupplyDip721 "$DEFAULT_HOME" "$nonFungibleContractAddress"
 
-  # balanceOfDip721 "$DEFAULT_HOME" "$nonFungibleContractAddress"
+  balanceOfDip721 "$DEFAULT_HOME" "$nonFungibleContractAddress"
   
-  # ownerOfDip721 "$DEFAULT_HOME" "$nonFungibleContractAddress" "$nft_token_id_for_alice"
+  ownerOfDip721 "$DEFAULT_HOME" "$nonFungibleContractAddress" "$nft_token_id_for_alice"
 
-  # safeTransferFromDip721 "$ALICE_HOME" "$ALICE_PRINCIPAL_ID" "$BOB_PRINCIPAL_ID" "$nft_token_id_for_alice"
+  safeTransferFromDip721 "$ALICE_HOME" "$ALICE_PRINCIPAL_ID" "$BOB_PRINCIPAL_ID" "$nft_token_id_for_alice"
 
-  # transferFromDip721 "$BOB_HOME" "$BOB_PRINCIPAL_ID" "$ALICE_PRINCIPAL_ID" "$nft_token_id_for_alice"
+  transferFromDip721 "$BOB_HOME" "$BOB_PRINCIPAL_ID" "$ALICE_PRINCIPAL_ID" "$nft_token_id_for_alice"
 
-  # transfer "$ALICE_HOME" "$ALICE_PRINCIPAL_ID" "$BOB_PRINCIPAL_ID" "$nft_token_id_for_alice" 1
+  transfer "$ALICE_HOME" "$ALICE_PRINCIPAL_ID" "$BOB_PRINCIPAL_ID" "$nft_token_id_for_alice" 1
 
   ### not testable
   # printf "Running mintNFT"

--- a/.scripts/required/healthcheck-run-verification.sh
+++ b/.scripts/required/healthcheck-run-verification.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [ -d ./.dfx/local/canisters/nft ] && [[ ! SKIP_PROMPTS -eq 1 ]];
+if [ -d ./.dfx/local/canisters/nft ] && [[ ! SKIP_PROMPTS -eq 1 ]] && [[ ! CI -eq 1 ]];
 then
   printf "🚩 The process seem to have run before, it's probably best to reset the state and only after run the healthcheck, please!\n\n"  
 


### PR DESCRIPTION
## Why?

The prefix should only affect the exec context and not override and the deploy should explicitly show to the user the initial owner

## How?

- Changes prefix for dfx commands
