### PR TITLE
docs: (spec) private property prefix, remove data blob

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -594,18 +594,6 @@ type TokenMetadata = record {
 
 All of the following are reserved by the spec to verify and display assets across all applications.
 
-Noted that `data` and `location` are mutual exclusive, only one of them is required.
-
-#### data - **Required**
-
----
-
-blob asset data.
-
-```
-{"data", BlobContent(<blob asset data of the NFT>)}
-```
-
 #### location - **Required**
 
 ---
@@ -645,6 +633,18 @@ URL location for the preview thumbnail for asset content
 ```
 {"thumbnail", TextContent(<thumbnail URL of the NFT>)}
 ```
+
+#### Private properties - **Optional**
+
+---
+
+To store any private properties that should not be displayed in a dapps frontend (eg. Plug Wallet's trait chips), simply prefix the key with an `_`.
+
+```
+{"_hidden", TextContent(<developer-focused property>)}
+```
+
+Developers should keep in mind though, that storing large amounts of data directly in the metadata could lead to errors due to the IC's 2MB message limit, and is not recommended.
 
 <br>
 


### PR DESCRIPTION
## Why?

Based on some feedback from the community (cc @jorgenbuilder ), there is a need for specifying if a given key value should be displayed in frontends (eg; plug wallet's trait chips).

This also removes the requirement of the data blob, as storing large amounts of data in the meta is not recommended, due to the IC's 2MB message limit.

## How?

Adds the `_` prefix for private properties to the spec

Removed reserved property `data` 

## Tickets?

n.a

## Contribution checklist?

- [ ] The commit messages are detailed
- [ ] It does not break existing features (unless required)
- [ ] I have performed a self-review of my own code
- [ ] Documentation has been updated to reflect the changes
- [ ] Tests have been added or updated to reflect the changes
- [ ] All code formatting pass
- [ ] All lints pass
- [ ] All tests pass

## Security checklist?

n.a

## Demo?
n.a
